### PR TITLE
Fix serializer class not found error

### DIFF
--- a/src/main/java/io/github/aload0/presto/eventlistener/producer/PrestoEventProducer.java
+++ b/src/main/java/io/github/aload0/presto/eventlistener/producer/PrestoEventProducer.java
@@ -79,7 +79,7 @@ class PrestoEventProducer
             producer.send(new ProducerRecord<>(topic, value));
         }
         catch (Exception e) {
-            LOG.error("Sending event {} error", e);
+            LOG.error("Sending event {} error", event, e);
         }
     }
 
@@ -126,6 +126,18 @@ class PrestoEventProducer
             this.type = type;
             this.coordinator = coordinator;
         }
+
+        @Override
+        public String toString()
+        {
+            final StringBuilder sb = new StringBuilder("PrestoEventHolder{");
+            sb.append("time=").append(time);
+            sb.append(", event=").append(event);
+            sb.append(", type=").append(type);
+            sb.append(", coordinator='").append(coordinator).append('\'');
+            sb.append('}');
+            return sb.toString();
+        }
     }
 
     static class KafkaProducerFactory
@@ -165,7 +177,13 @@ class PrestoEventProducer
                     }
                 }
             });
-            return new KafkaProducer<>(properties);
+
+            // See https://stackoverflow.com/a/54118010
+            ClassLoader original = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(null);
+            KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
+            Thread.currentThread().setContextClassLoader(original);
+            return producer;
         }
     }
 }


### PR DESCRIPTION
Fix the following error:

```
ERROR   main    com.facebook.presto.server.PrestoServer Invalid value org.apache.kafka.common.serialization.StringSerializer for configuration key.serializer: Class org.apache.kafka.common.serializat
ion.StringSerializer could not be found.
org.apache.kafka.common.config.ConfigException: Invalid value org.apache.kafka.common.serialization.StringSerializer for configuration key.serializer: Class org.apache.kafka.common.serialization.StringSerializer could not be found.
        at org.apache.kafka.common.config.ConfigDef.parseType(ConfigDef.java:715)
        at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:460)
        at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:453)
        at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:62)
        at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:75)
        at org.apache.kafka.clients.producer.ProducerConfig.<init>(ProducerConfig.java:360)
        at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:291)
        at io.github.aload0.presto.eventlistener.producer.PrestoEventProducer$KafkaProducerFactory.create(PrestoEventProducer.java:168)
        at io.github.aload0.presto.eventlistener.producer.PrestoEventProducer$KafkaProducerFactory.create(PrestoEventProducer.java:135)
        at io.github.aload0.presto.eventlistener.producer.PrestoEventProducer.<init>(PrestoEventProducer.java:71)
        at io.github.aload0.presto.eventlistener.producer.PrestoEventProducer.create(PrestoEventProducer.java:41)
        at io.github.aload0.presto.eventlistener.producer.PrestoEventProducerPlugin$1.create(PrestoEventProducerPlugin.java:40)
        at com.facebook.presto.eventlistener.EventListenerManager.setConfiguredEventListener(EventListenerManager.java:82)
        at com.facebook.presto.eventlistener.EventListenerManager.loadConfiguredEventListener(EventListenerManager.java:67)
        at com.facebook.presto.server.PrestoServer.run(PrestoServer.java:132)
        at com.facebook.presto.server.PrestoServer.main(PrestoServer.java:67)
```

See also: https://stackoverflow.com/q/37363119